### PR TITLE
Zapamiętywanie wybranych kolumn pomiędzy podstronami

### DIFF
--- a/index.php
+++ b/index.php
@@ -51,8 +51,11 @@ while ($row = $query->fetch(PDO::FETCH_ASSOC)) {
 // Pobierz listy (do opcji i headera)
 $lists = $pdo->query("SELECT id, list_name FROM lists ORDER BY list_name")->fetchAll(PDO::FETCH_ASSOC);
 
-// Domyślne kolumny
+// Domyślne kolumny (wspólne ustawienie między podstronami)
 $defaultVisibleColumns = ['numer_ewidencyjny', 'nazwa_tytul', 'autor_wytworca'];
+$selectedColumns = isset($_SESSION['visible_columns']) && is_array($_SESSION['visible_columns'])
+    ? array_values(array_intersect($columns, $_SESSION['visible_columns']))
+    : $defaultVisibleColumns;
 ?>
 <!DOCTYPE html>
 <html lang="pl">
@@ -111,7 +114,7 @@ $defaultVisibleColumns = ['numer_ewidencyjny', 'nazwa_tytul', 'autor_wytworca'];
             <label>
                 <input type="checkbox" class="column-checkbox" value="<?php echo $col; ?>" 
                        onclick="toggleColumn('<?php echo $col; ?>')" 
-                       <?php echo in_array($col, $defaultVisibleColumns) ? 'checked' : ''; ?>>
+                       <?php echo in_array($col, $selectedColumns) ? 'checked' : ''; ?>>
                 <?php echo $col; ?>
             </label>
         <?php endforeach; ?>
@@ -123,7 +126,7 @@ $defaultVisibleColumns = ['numer_ewidencyjny', 'nazwa_tytul', 'autor_wytworca'];
                 <tr>
                     <?php foreach ($columns as $col): ?>
                         <th class="<?php echo $col; ?>" 
-                            style="display: <?php echo in_array($col, $defaultVisibleColumns) ? '' : 'none'; ?>;">
+                            style="display: <?php echo in_array($col, $selectedColumns) ? '' : 'none'; ?>;">
                             <?php echo $col; ?>
                         </th>
                     <?php endforeach; ?>
@@ -140,7 +143,7 @@ $defaultVisibleColumns = ['numer_ewidencyjny', 'nazwa_tytul', 'autor_wytworca'];
 const phpLists = <?php echo json_encode($lists); ?>;
 
 // Kolumny widoczne na start
-const defaultVisibleColumns = <?php echo json_encode($defaultVisibleColumns); ?>;
+const defaultVisibleColumns = <?php echo json_encode($selectedColumns); ?>;
 
 function toggleColumnSelector() {
     const container = document.getElementById('columnSelectorContainer');

--- a/list_view.php
+++ b/list_view.php
@@ -30,10 +30,14 @@ $lists = $pdo->query("SELECT id, list_name FROM lists ORDER BY list_name")->fetc
 // Domyślne widoczne kolumny
 $defaultVisibleColumns = ['numer_ewidencyjny', 'nazwa_tytul', 'autor_wytworca'];
 
-// Przechwytywanie wyboru kolumn przez POST lub domyślne
-$selectedColumns = $defaultVisibleColumns;
+// Przechwytywanie wyboru kolumn przez POST lub sesję (wspólne między podstronami)
+$selectedColumns = isset($_SESSION['visible_columns']) && is_array($_SESSION['visible_columns'])
+    ? array_values(array_intersect($columns, $_SESSION['visible_columns']))
+    : $defaultVisibleColumns;
+
 if (isset($_POST['visible_columns']) && is_array($_POST['visible_columns'])) {
     $selectedColumns = array_values(array_intersect($columns, $_POST['visible_columns']));
+    $_SESSION['visible_columns'] = $selectedColumns;
 }
 
 // Pobierz wpisy z danej listy

--- a/search.php
+++ b/search.php
@@ -24,9 +24,13 @@ $query_string = '';
 $levenshtein_distance = 2;
 
 // Przechwytywanie wyboru kolumn
-$selectedColumns = $defaultVisibleColumns;
+$selectedColumns = isset($_SESSION['visible_columns']) && is_array($_SESSION['visible_columns'])
+    ? array_values(array_intersect($columns, $_SESSION['visible_columns']))
+    : $defaultVisibleColumns;
+
 if (isset($_POST['visible_columns']) && is_array($_POST['visible_columns'])) {
     $selectedColumns = array_values(array_intersect($columns, $_POST['visible_columns']));
+    $_SESSION['visible_columns'] = $selectedColumns;
 }
 
 /** Utils **/


### PR DESCRIPTION
### Motivation
- Użytkownik powinien widzieć ten sam zestaw wybranych kolumn po przejściu między podstronami zamiast powrotu do domyślnych ustawień.

### Description
- W `list_view.php` dodano odczyt `$_SESSION['visible_columns']` jako domyślnego `$selectedColumns` oraz zapis z `POST` do `$_SESSION['visible_columns']` po zatwierdzeniu formularza.
- W `search.php` wprowadzono analogiczne odczyty/zapisy sesyjne dla `visible_columns`, aby wybór kolumn z wyszukiwarki był globalny.
- W `index.php` zastąpiono bezpośrednie użycie `$defaultVisibleColumns` przez `$selectedColumns` (odczytywane z sesji) i przekazanie tego stanu do JS, aby strona główna korzystała z tego samego zapamiętanego zestawu kolumn.
- Zastosowano walidację wyboru przez `array_intersect($columns, ...)`, z zachowaniem domyślnego fallbacku `['numer_ewidencyjny','nazwa_tytul','autor_wytworca']`.

### Testing
- Uruchomiono składnię PHP linterem poleceniem `php -l index.php && php -l list_view.php && php -l search.php`, które zwróciło brak błędów składniowych (sukces).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6997fb4de0448320ae9d726da9603505)