### PR TITLE
Ujednolicenie wyglądu niebieskich przycisków

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -10,8 +10,23 @@ body { font-family: Arial, sans-serif; padding: 20px; }
 .header-links a { margin-left: 15px; text-decoration: none; color: #fff; }
 .header-links a:hover { text-decoration: underline; color: #000; }
 #columnSelectorContainer { display: none; padding: 10px; border: 1px solid #ccc; background-color: #f9f9f9; }
-#toggleButton, #toggleColumndButton { font-family: Arial, sans-serif; font-size: 4; cursor: pointer; margin-bottom: 15px; background-color: #007BFF; color: white; border: 1px; padding: 8px 16px; border-radius: 5px; }
-#toggleButton:focus { outline: none; font-family: Arial, sans-serif; font-size: 4; }
+#toggleButton,
+#toggleColumndButton {
+    display: inline-block;
+    font-family: Arial, sans-serif;
+    font-size: 16px;
+    line-height: 1.2;
+    cursor: pointer;
+    margin-bottom: 15px;
+    background-color: #007BFF;
+    color: white;
+    border: none;
+    padding: 8px 16px;
+    border-radius: 5px;
+    text-decoration: none;
+}
+#toggleButton:focus,
+#toggleColumndButton:focus { outline: none; }
 
 /* Page-specific additions from other PHP files */
 .header { display: flex; align-items: center; gap: 16px; }


### PR DESCRIPTION
### Motivation
- Ujednolicić wygląd wszystkich niebieskich przycisków/odnośników, ponieważ przycisk „Wybierz kolumny” miał inny rozmiar czcionki (wynikający z niepoprawnej wartości `font-size: 4`) niż np. „Wyloguj się”.

### Description
- Zmieniono regułę CSS dla selektorów `#toggleButton, #toggleColumndButton`, ustawiając m.in. `display: inline-block`, `font-size: 16px`, `line-height: 1.2`, `border: none`, `padding: 8px 16px`, `border-radius: 5px` oraz usunięto niejednoznaczną wartość `font-size`, a styl focus uproszczono tak, aby oba selektory miały identyczne zachowanie.

### Testing
- Uruchomiono kontrolę składni `php -l index.php` oraz wystawiono lokalny serwer `php -S` i wykonano zrzut strony testem Playwright odwiedzając `http://127.0.0.1:8000/index.php`, oba kroki zakończyły się pomyślnie.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69981bfb20c88320bc6cc539ff64f033)