### PR TITLE
Fix WOFF2 font visibility on page headings

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -1,3 +1,9 @@
+@font-face {
+    font-family: 'GrohmanGrotesk';
+    src: url('gg.woff2') format('woff2');
+    font-display: swap;
+}
+
 /* Global base styles (from index.php) */
 body { font-family: Arial, sans-serif; padding: 20px; }
 .column-selector, .data-table { margin-top: 20px; }
@@ -90,8 +96,7 @@ button:focus { outline: none; }
 .footer-right a:hover { text-decoration: underline; }
 
 h1, h2, h3 {
-    font-family: GrohmanGrotesk;
-    src: url('/gg.woff2') format('woff2');
+    font-family: 'GrohmanGrotesk', Arial, sans-serif;
 }
 
 .lists-table, .entries-table { border-collapse: collapse; width: 100%; margin-bottom: 30px; }


### PR DESCRIPTION
### Motivation
- Headings were not rendering the custom WOFF2 font because the font declaration was incorrectly placed in a selector rule instead of a proper `@font-face` block.
- The change ensures the custom `GrohmanGrotesk` font is loaded correctly with a safe fallback so headings remain readable if the font cannot be loaded.

### Description
- Added a proper `@font-face` declaration for `GrohmanGrotesk` referencing `gg.woff2` in `styles.css` and enabled `font-display: swap`.
- Updated the `h1, h2, h3` rule to use `font-family: 'GrohmanGrotesk', Arial, sans-serif;` and removed the invalid `src` usage from the selector.
- Adjusted CSS formatting to keep the new `@font-face` at the top of `styles.css` so the font is available to the rest of the stylesheet.

### Testing
- Started a local PHP dev server with `php -S 0.0.0.0:8000 -t /workspace/baza` which successfully served the project and the font file.
- Verified the font file is served with `curl -I http://127.0.0.1:8000/gg.woff2` which returned `HTTP/1.1 200 OK` and `Content-Type: font/woff2`.
- Captured a full-page screenshot using Playwright (`artifacts/font-fix.png`) after the change to validate headings render with the updated font configuration.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699820d0e2f08320b98ce952151d6c13)