### PR TITLE
Ustaw kolor hover przycisków na #074188

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -133,6 +133,19 @@ button,
     font-size: 12px;
 }
 
+button:hover,
+#toggleButton:hover,
+#toggleColumndButton:hover,
+#toggleColumnButton:hover,
+#togglePrzemieszczeniaButton:hover,
+#toggleBulkPrzemieszczenieButton:hover,
+#toggleCommonPrzemieszczeniaButton:hover,
+.edit-btn:hover,
+.delete-btn:hover,
+.remove-btn:hover {
+    background-color: #074188;
+}
+
 button:focus,
 #toggleButton:focus,
 #toggleColumndButton:focus,


### PR DESCRIPTION
### Motivation
- Ujednolicić wygląd interakcji przycisków poprzez ustawienie koloru tła w stanie `:hover` na wartości wymaganej przez projekt (`#074188`).

### Description
- Dodano regułę CSS w `styles.css` dla selektorów `button`, `#toggle*` oraz klas `.edit-btn`, `.delete-btn`, `.remove-btn`, ustawiając `background-color: #074188` dla stanu `:hover`.
- Zmiana została zapisana i zatwierdzona w repozytorium (plik `styles.css`).

### Testing
- Sprawdzono różnicę zmian za pomocą `git diff` i potwierdzono commit z wiadomością `Ustaw kolor hover przycisków na #074188`.
- Uruchomiono lokalny serwer PHP (`php -S 0.0.0.0:8000 -t /workspace/baza`) i zweryfikowano, że strona ładuje się poprawnie poprzez `curl http://127.0.0.1:8000/login.php`.
- Próba automatycznego zrzutu ekranu z użyciem Playwright zakończyła się niepowodzeniem z powodu błędu środowiskowego przeglądarki w kontenerze, więc wizualna weryfikacja screenshotem nie została wygenerowana.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699850d2184c832084643880503b8468)