### PR TITLE
Poprawa przewijania i zachowania przycisków Pokaż/Ukryj w karta.php

### DIFF
--- a/karta.php
+++ b/karta.php
@@ -248,7 +248,7 @@ $nextPrzemieszczeniaNumber = getNextPrzemieszczenieNumber($pdo);
     </table>
 
     <!-- Tabela Edycji Karty -->
-    <button id="toggleEditKartaButton" onclick="toggleEditKarta()">Pokaż/Ukryj tabelę edycji karty</button>
+    <button type="button" id="toggleEditKartaButton" onclick="toggleEditKarta()">Pokaż/Ukryj tabelę edycji karty</button>
     <div id="editKartaContainer">
         <h2>Edytuj Kartę</h2>
         <form method="post">
@@ -266,7 +266,7 @@ $nextPrzemieszczeniaNumber = getNextPrzemieszczenieNumber($pdo);
     </div>
 
     <!-- Tabela Historii Zmian -->
-    <button id="toggleLogButton" onclick="toggleLog()">Pokaż/Ukryj historię zmian</button>
+    <button type="button" id="toggleLogButton" onclick="toggleLog()">Pokaż/Ukryj historię zmian</button>
     <div id="logContainer">
         <h2>Historia Zmian</h2>
         <table>
@@ -294,7 +294,7 @@ $nextPrzemieszczeniaNumber = getNextPrzemieszczenieNumber($pdo);
     </div>
 
     <!-- Tabela Przemieszczeń -->
-    <button id="togglePrzemieszczeniaButton" onclick="togglePrzemieszczenia()">Pokaż/Ukryj tabelę przemieszczeń</button>
+    <button type="button" id="togglePrzemieszczeniaButton" onclick="togglePrzemieszczenia()">Pokaż/Ukryj tabelę przemieszczeń</button>
     <div id="przemieszczeniaContainer">
         <h2>Przemieszczenia</h2>
         <table>
@@ -362,17 +362,30 @@ $nextPrzemieszczeniaNumber = getNextPrzemieszczenieNumber($pdo);
     </div>
 
     <script>
+        function toggleContainer(containerId) {
+            const container = document.getElementById(containerId);
+            if (!container) {
+                return;
+            }
+
+            const isHidden = container.style.display === 'none' || container.style.display === '';
+            container.style.display = isHidden ? 'block' : 'none';
+
+            if (isHidden) {
+                container.scrollIntoView({ behavior: 'smooth', block: 'start' });
+            }
+        }
+
         function toggleEditKarta() {
-            const container = document.getElementById('editKartaContainer');
-            container.style.display = container.style.display === 'none' || container.style.display === '' ? 'block' : 'none';
+            toggleContainer('editKartaContainer');
         }
+
         function toggleLog() {
-            const container = document.getElementById('logContainer');
-            container.style.display = container.style.display === 'none' || container.style.display === '' ? 'block' : 'none';
+            toggleContainer('logContainer');
         }
+
         function togglePrzemieszczenia() {
-            const container = document.getElementById('przemieszczeniaContainer');
-            container.style.display = container.style.display === 'none' || container.style.display === '' ? 'block' : 'none';
+            toggleContainer('przemieszczeniaContainer');
         }
 
         window.addEventListener('DOMContentLoaded', () => {


### PR DESCRIPTION
### Motivation
- Użytkownik wymagał, aby kliknięcie któregokolwiek przycisku „Pokaż/Ukryj” nie tylko ujawniało odpowiednią sekcję, ale też przewijało stronę tak, aby wyświetlona tabela była od razu widoczna.
- Trzeba było też zapobiec przypadkowemu wywoływaniu zachowań formularza przez te przyciski.

### Description
- Zmieniono atrybut przycisków przełączających na `type="button"`, aby kliknięcie nie powodowało submitu formularza w `karta.php`.
- Zrefaktoryzowano logikę przełączania do wspólnej funkcji `toggleContainer(containerId)` i podłączono do niej `toggleEditKarta`, `toggleLog` oraz `togglePrzemieszczenia`.
- Po pokazaniu sekcji dodano automatyczne przewinięcie do wyświetlonego kontenera za pomocą `scrollIntoView({ behavior: 'smooth', block: 'start' })`.
- Modyfikowany plik: `karta.php`.

### Testing
- Sprawdzono składnię pliku za pomocą `php -l karta.php` i otrzymano informacje o braku błędów.
- Uruchomiono lokalny serwer programistyczny `php -S 0.0.0.0:8000 -t /workspace/baza` i serwer wystartował poprawnie.
- Wykonano skrypt Playwright, który otworzył `http://127.0.0.1:8000/karta.php?id=1` i zapisał screenshot (`artifacts/karta-toggle-change.png`), co potwierdziło widoczność i przewijanie; test zakończył się pomyślnie.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69985c1737288320a7aa8bc6b8e32c2b)