### PR TITLE
Dodaj przełącznik kolekcji i skrypt tworzenia tabel

### DIFF
--- a/add_list.php
+++ b/add_list.php
@@ -9,23 +9,40 @@ if (!isset($_SESSION['user_id'])) {
     exit;
 }
 
+function ensureListsCollectionColumn(PDO $pdo): void {
+    $columns = $pdo->query("SHOW COLUMNS FROM lists")->fetchAll(PDO::FETCH_COLUMN, 0);
+    if (!in_array('collection', $columns, true)) {
+        $pdo->exec("ALTER TABLE lists ADD COLUMN collection VARCHAR(64) NOT NULL DEFAULT 'ksiazki-artystyczne'");
+    }
+}
+
+$allowedCollections = ['ksiazki-artystyczne', 'kolekcja-maszyn', 'kolekcja-matryc', 'biblioteka'];
+
 $input = json_decode(file_get_contents('php://input'), true);
 $name = trim($input['name'] ?? '');
 $entry_id = isset($input['entry_id']) ? (int)$input['entry_id'] : 0;
+$collection = $input['collection'] ?? 'ksiazki-artystyczne';
 $user = (int)$_SESSION['user_id'];
 
-if ($name === '' || $entry_id <= 0) {
-    echo json_encode(['success' => false, 'message' => 'Brak wymaganych danych.']);
+if (!in_array($collection, $allowedCollections, true)) {
+    $collection = 'ksiazki-artystyczne';
+}
+
+if ($name === '') {
+    echo json_encode(['success' => false, 'message' => 'Brak nazwy listy.']);
     exit;
 }
 
-$stmt = $pdo->prepare("INSERT INTO lists (list_name, user) VALUES (?, ?)");
-$stmt->execute([$name, $user]);
+ensureListsCollectionColumn($pdo);
+
+$stmt = $pdo->prepare("INSERT INTO lists (list_name, user, collection) VALUES (?, ?, ?)");
+$stmt->execute([$name, $user, $collection]);
 
 $list_id = (int)$pdo->lastInsertId();
 
-$stmt = $pdo->prepare("INSERT INTO list_items (list_id, entry_id) VALUES (?, ?)");
-$success = $stmt->execute([$list_id, $entry_id]);
+if ($entry_id > 0) {
+    $stmt = $pdo->prepare("INSERT INTO list_items (list_id, entry_id) VALUES (?, ?)");
+    $stmt->execute([$list_id, $entry_id]);
+}
 
-echo json_encode(['success' => $success, 'list_id' => $list_id]);
-?>
+echo json_encode(['success' => true, 'list_id' => $list_id, 'id' => $list_id]);

--- a/create_collection_tables.sql
+++ b/create_collection_tables.sql
@@ -1,0 +1,14 @@
+-- Tworzy dodatkowe kolekcje o takiej samej strukturze jak podstawowe tabele.
+-- Uruchom po połączeniu z docelową bazą danych (USE nazwa_bazy;).
+
+CREATE TABLE IF NOT EXISTS karta_ewidencyjna_maszyny LIKE karta_ewidencyjna;
+CREATE TABLE IF NOT EXISTS karta_ewidencyjna_maszyny_log LIKE karta_ewidencyjna_log;
+CREATE TABLE IF NOT EXISTS karta_ewidencyjna_maszyny_przemieszczenia LIKE karta_ewidencyjna_przemieszczenia;
+
+CREATE TABLE IF NOT EXISTS karta_ewidencyjna_matryce LIKE karta_ewidencyjna;
+CREATE TABLE IF NOT EXISTS karta_ewidencyjna_matryce_log LIKE karta_ewidencyjna_log;
+CREATE TABLE IF NOT EXISTS karta_ewidencyjna_matryce_przemieszczenia LIKE karta_ewidencyjna_przemieszczenia;
+
+CREATE TABLE IF NOT EXISTS karta_ewidencyjna_bib LIKE karta_ewidencyjna;
+CREATE TABLE IF NOT EXISTS karta_ewidencyjna_bib_log LIKE karta_ewidencyjna_log;
+CREATE TABLE IF NOT EXISTS karta_ewidencyjna_bib_przemieszczenia LIKE karta_ewidencyjna_przemieszczenia;

--- a/create_collection_tables.sql
+++ b/create_collection_tables.sql
@@ -1,14 +1,29 @@
--- Tworzy dodatkowe kolekcje o takiej samej strukturze jak podstawowe tabele.
--- Uruchom po połączeniu z docelową bazą danych (USE nazwa_bazy;).
+-- Skrypt tworzy 3 dodatkowe kolekcje przez pełne klonowanie struktury tabel bazowych.
+-- Dzięki CREATE TABLE ... LIKE ... kopiowany jest cały układ tabeli źródłowej:
+-- kolumny, typy, wartości domyślne, indeksy oraz AUTO_INCREMENT.
+--
+-- WAŻNE:
+-- tabela użytkowników jest jedna wspólna: karta_ewidencyjna_users
+-- i NIE jest duplikowana dla pozostałych kolekcji.
 
+-- KOLEKCJA MASZYN
 CREATE TABLE IF NOT EXISTS karta_ewidencyjna_maszyny LIKE karta_ewidencyjna;
 CREATE TABLE IF NOT EXISTS karta_ewidencyjna_maszyny_log LIKE karta_ewidencyjna_log;
 CREATE TABLE IF NOT EXISTS karta_ewidencyjna_maszyny_przemieszczenia LIKE karta_ewidencyjna_przemieszczenia;
 
+-- KOLEKCJA MATRYC
 CREATE TABLE IF NOT EXISTS karta_ewidencyjna_matryce LIKE karta_ewidencyjna;
 CREATE TABLE IF NOT EXISTS karta_ewidencyjna_matryce_log LIKE karta_ewidencyjna_log;
 CREATE TABLE IF NOT EXISTS karta_ewidencyjna_matryce_przemieszczenia LIKE karta_ewidencyjna_przemieszczenia;
 
+-- BIBLIOTEKA
 CREATE TABLE IF NOT EXISTS karta_ewidencyjna_bib LIKE karta_ewidencyjna;
 CREATE TABLE IF NOT EXISTS karta_ewidencyjna_bib_log LIKE karta_ewidencyjna_log;
 CREATE TABLE IF NOT EXISTS karta_ewidencyjna_bib_przemieszczenia LIKE karta_ewidencyjna_przemieszczenia;
+
+-- (opcjonalnie) szybkie kontrole porównania liczby kolumn:
+-- SELECT 'karta_ewidencyjna' AS src, COUNT(*) AS cols FROM information_schema.columns
+-- WHERE table_schema = DATABASE() AND table_name = 'karta_ewidencyjna'
+-- UNION ALL
+-- SELECT 'karta_ewidencyjna_maszyny', COUNT(*) FROM information_schema.columns
+-- WHERE table_schema = DATABASE() AND table_name = 'karta_ewidencyjna_maszyny';

--- a/index.php
+++ b/index.php
@@ -141,11 +141,11 @@ $selectedColumns = isset($_SESSION['visible_columns']) && is_array($_SESSION['vi
  
 
 <div class="header-low">
-    <a role="button" id="toggleButton" href="lists.php">Edytor list</a>
+    <a role="button" id="toggleButton" href="lists.php?collection=<?php echo urlencode($selectedCollection); ?>">Edytor list</a>
 <strong>Listy:</strong>
             <?php
             foreach ($lists as $list) {
-                echo "<a href='list_view.php?list_id={$list['id']}'>{$list['list_name']}</a> &nbsp; ";
+                echo "<a href='list_view.php?list_id={$list['id']}&collection=" . urlencode($selectedCollection) . "'>{$list['list_name']}</a> &nbsp; ";
             }
             ?>
 
@@ -166,9 +166,9 @@ $selectedColumns = isset($_SESSION['visible_columns']) && is_array($_SESSION['vi
 
     <button id="toggleColumndButton" onclick="toggleColumnSelector()">Wybierz kolumny</button>
     
-    <a role="button" id="toggleButton" href="neww.php">Nowy Wpis</a> 
+    <a role="button" id="toggleButton" href="neww.php?collection=<?php echo urlencode($selectedCollection); ?>">Nowy Wpis</a> 
     
-    <a role="button" id="toggleButton" href="search.php">Szukaj</a>
+    <a role="button" id="toggleButton" href="search.php?collection=<?php echo urlencode($selectedCollection); ?>">Szukaj</a>
    
  </div>
     <div id="columnSelectorContainer" class="column-selector">
@@ -229,7 +229,7 @@ function persistVisibleColumns() {
         visibleColumns.push(cb.value);
     });
 
-    fetch('?action=save_visible_columns', {
+    fetch(`?collection=${encodeURIComponent(selectedCollection)}&action=save_visible_columns`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ visible_columns: visibleColumns })
@@ -323,7 +323,7 @@ function loadRows() {
     if (loading || noMoreRows) return;
     loading = true;
 
-    fetch(`?action=fetch_rows&offset=${offset}`)
+    fetch(`?collection=${encodeURIComponent(selectedCollection)}&action=fetch_rows&offset=${offset}`)
         .then(async response => {
             if (!response.ok) {
                 const text = await response.text();

--- a/lists.php
+++ b/lists.php
@@ -11,56 +11,80 @@ if (!isset($_SESSION['user_id'])) {
     exit;
 }
 
-// Edycja nazwy listy
-if (isset($_POST['edit_list']) && isset($_POST['list_id'], $_POST['list_name'])) {
-    $stmt = $pdo->prepare("UPDATE lists SET list_name = ? WHERE id = ?");
-    $stmt->execute([trim($_POST['list_name']), (int)$_POST['list_id']]);
-    header("Location: lists.php?edit={$_POST['list_id']}");
+$collections = [
+    'ksiazki-artystyczne' => 'karta_ewidencyjna',
+    'kolekcja-maszyn' => 'karta_ewidencyjna_maszyny',
+    'kolekcja-matryc' => 'karta_ewidencyjna_matryce',
+    'biblioteka' => 'karta_ewidencyjna_bib',
+];
+
+$selectedCollection = $_GET['collection'] ?? ($_POST['collection'] ?? 'ksiazki-artystyczne');
+if (!isset($collections[$selectedCollection])) {
+    $selectedCollection = 'ksiazki-artystyczne';
+}
+$mainTable = $collections[$selectedCollection];
+
+$columns = $pdo->query("SHOW COLUMNS FROM lists")->fetchAll(PDO::FETCH_COLUMN, 0);
+if (!in_array('collection', $columns, true)) {
+    $pdo->exec("ALTER TABLE lists ADD COLUMN collection VARCHAR(64) NOT NULL DEFAULT 'ksiazki-artystyczne'");
+}
+
+function collectionRedirect(string $collection, string $suffix = ''): void {
+    header("Location: lists.php?collection=" . urlencode($collection) . $suffix);
     exit;
 }
 
-// Usuwanie listy
+if (isset($_POST['edit_list']) && isset($_POST['list_id'], $_POST['list_name'])) {
+    $stmt = $pdo->prepare("UPDATE lists SET list_name = ? WHERE id = ? AND collection = ?");
+    $stmt->execute([trim($_POST['list_name']), (int)$_POST['list_id'], $selectedCollection]);
+    collectionRedirect($selectedCollection, '&edit=' . (int)$_POST['list_id']);
+}
+
 if (isset($_POST['delete_list']) && isset($_POST['list_id'])) {
     $list_id = (int)$_POST['list_id'];
-    $pdo->prepare("DELETE FROM list_items WHERE list_id = ?")->execute([$list_id]);
-    $pdo->prepare("DELETE FROM lists WHERE id = ?")->execute([$list_id]);
-    header("Location: lists.php");
-    exit;
+    $pdo->prepare("DELETE li FROM list_items li JOIN lists l ON l.id = li.list_id WHERE li.list_id = ? AND l.collection = ?")
+        ->execute([$list_id, $selectedCollection]);
+    $pdo->prepare("DELETE FROM lists WHERE id = ? AND collection = ?")->execute([$list_id, $selectedCollection]);
+    collectionRedirect($selectedCollection);
 }
 
-// Usuwanie wpisu z listy
 if (isset($_POST['remove_entry']) && isset($_POST['entry_id'], $_POST['list_id'])) {
-    $pdo->prepare("DELETE FROM list_items WHERE list_id = ? AND entry_id = ?")->execute([
-        (int)$_POST['list_id'], (int)$_POST['entry_id']
-    ]);
-    header("Location: lists.php?edit={$_POST['list_id']}");
-    exit;
+    $pdo->prepare("DELETE li FROM list_items li JOIN lists l ON l.id = li.list_id WHERE li.list_id = ? AND li.entry_id = ? AND l.collection = ?")
+        ->execute([(int)$_POST['list_id'], (int)$_POST['entry_id'], $selectedCollection]);
+    collectionRedirect($selectedCollection, '&edit=' . (int)$_POST['list_id']);
 }
 
-// Dodawanie wpisu do listy (po ID karty)
 if (isset($_POST['add_entry']) && isset($_POST['list_id'], $_POST['entry_id'])) {
-    $pdo->prepare("INSERT IGNORE INTO list_items (list_id, entry_id) VALUES (?, ?)")->execute([
-        (int)$_POST['list_id'], (int)$_POST['entry_id']
-    ]);
-    header("Location: lists.php?edit={$_POST['list_id']}");
-    exit;
+    $check = $pdo->prepare("SELECT id FROM lists WHERE id = ? AND collection = ?");
+    $check->execute([(int)$_POST['list_id'], $selectedCollection]);
+    if ($check->fetchColumn()) {
+        $pdo->prepare("INSERT IGNORE INTO list_items (list_id, entry_id) VALUES (?, ?)")
+            ->execute([(int)$_POST['list_id'], (int)$_POST['entry_id']]);
+    }
+    collectionRedirect($selectedCollection, '&edit=' . (int)$_POST['list_id']);
 }
 
-// Pobierz listy
-$lists = $pdo->query("SELECT * FROM lists ORDER BY list_name")->fetchAll(PDO::FETCH_ASSOC);
+$listStmt = $pdo->prepare("SELECT * FROM lists WHERE collection = ? ORDER BY list_name");
+$listStmt->execute([$selectedCollection]);
+$lists = $listStmt->fetchAll(PDO::FETCH_ASSOC);
 
-// Wybrana lista do edycji
 $edit_list = null;
 $list_entries = [];
 if (isset($_GET['edit']) && ctype_digit($_GET['edit'])) {
     $edit_id = (int)$_GET['edit'];
-    $edit_list = $pdo->query("SELECT * FROM lists WHERE id = $edit_id")->fetch(PDO::FETCH_ASSOC);
-    // Zawartość listy z danymi rekordów
-    $list_entries = $pdo->query(
-        "SELECT e.*, li.entry_id FROM list_items li
-         JOIN karta_ewidencyjna e ON li.entry_id = e.ID
-         WHERE li.list_id = $edit_id"
-    )->fetchAll(PDO::FETCH_ASSOC);
+    $editStmt = $pdo->prepare("SELECT * FROM lists WHERE id = ? AND collection = ?");
+    $editStmt->execute([$edit_id, $selectedCollection]);
+    $edit_list = $editStmt->fetch(PDO::FETCH_ASSOC);
+
+    if ($edit_list) {
+        $entriesStmt = $pdo->prepare(
+            "SELECT e.*, li.entry_id FROM list_items li
+             JOIN {$mainTable} e ON li.entry_id = e.ID
+             WHERE li.list_id = ?"
+        );
+        $entriesStmt->execute([$edit_id]);
+        $list_entries = $entriesStmt->fetchAll(PDO::FETCH_ASSOC);
+    }
 }
 ?>
 <!DOCTYPE html>
@@ -68,32 +92,29 @@ if (isset($_GET['edit']) && ctype_digit($_GET['edit'])) {
 <head>
     <meta charset="UTF-8">
     <title>Zarządzanie listami | baza.mkal.pl</title>
-        <link rel="stylesheet" href="styles.css">
+    <link rel="stylesheet" href="styles.css">
 </head>
 <body>
-    <a role="button" id="toggleButton" href="https://baza.mkal.pl" class="back-link">Powrót do strony głównej</a>
-    <h2>Listy</h2>
+    <a role="button" id="toggleButton" href="index.php?collection=<?php echo urlencode($selectedCollection); ?>" class="back-link">Powrót do strony głównej</a>
+    <h2>Listy (<?php echo htmlspecialchars($selectedCollection); ?>)</h2>
 
     <?php if ($edit_list): ?>
         <h3>Edycja listy: <?php echo htmlspecialchars($edit_list['list_name']); ?></h3>
         <form method="post" style="margin-bottom:10px;">
+            <input type="hidden" name="collection" value="<?php echo htmlspecialchars($selectedCollection); ?>">
             <input type="hidden" name="list_id" value="<?php echo $edit_list['id']; ?>">
             <input type="text" name="list_name" value="<?php echo htmlspecialchars($edit_list['list_name']); ?>" required>
             <button type="submit" name="edit_list" class="edit-btn">Zmień nazwę</button>
         </form>
         <form method="post" onsubmit="return confirm('Usunąć całą listę? Wszystkie przypisania zostaną usunięte.');" style="display:inline;">
+            <input type="hidden" name="collection" value="<?php echo htmlspecialchars($selectedCollection); ?>">
             <input type="hidden" name="list_id" value="<?php echo $edit_list['id']; ?>">
             <button type="submit" name="delete_list" class="delete-btn">Usuń listę</button>
         </form>
         <h4>Zawartość listy</h4>
         <table class="entries-table">
             <thead>
-                <tr>
-                    <th>ID</th>
-                    <th>Tytuł / Nazwa</th>
-                    <th>Autor/Wytwórca</th>
-                    <th>Opcje</th>
-                </tr>
+                <tr><th>ID</th><th>Tytuł / Nazwa</th><th>Autor/Wytwórca</th><th>Opcje</th></tr>
             </thead>
             <tbody>
                 <?php foreach ($list_entries as $entry): ?>
@@ -102,8 +123,9 @@ if (isset($_GET['edit']) && ctype_digit($_GET['edit'])) {
                     <td><?php echo htmlspecialchars($entry['nazwa_tytul']); ?></td>
                     <td><?php echo htmlspecialchars($entry['autor_wytworca']); ?></td>
                     <td>
-                        <a href="karta.php?id=<?php echo $entry['ID']; ?>" class="edit-btn" target="_blank">Karta</a>
+                        <a href="karta.php?id=<?php echo $entry['ID']; ?>&collection=<?php echo urlencode($selectedCollection); ?>" class="edit-btn" target="_blank">Karta</a>
                         <form method="post" class="form-inline" onsubmit="return confirm('Usunąć rekord z listy?');">
+                            <input type="hidden" name="collection" value="<?php echo htmlspecialchars($selectedCollection); ?>">
                             <input type="hidden" name="list_id" value="<?php echo $edit_list['id']; ?>">
                             <input type="hidden" name="entry_id" value="<?php echo $entry['ID']; ?>">
                             <button type="submit" name="remove_entry" class="remove-btn">Usuń z listy</button>
@@ -115,34 +137,31 @@ if (isset($_GET['edit']) && ctype_digit($_GET['edit'])) {
         </table>
         <h4>Dodaj rekord do listy (po ID karty):</h4>
         <form method="post" style="margin-bottom:30px;">
+            <input type="hidden" name="collection" value="<?php echo htmlspecialchars($selectedCollection); ?>">
             <input type="hidden" name="list_id" value="<?php echo $edit_list['id']; ?>">
             <input type="number" name="entry_id" placeholder="ID rekordu" min="1" required>
             <button type="submit" name="add_entry" class="edit-btn">Dodaj</button>
         </form>
-        <a href="lists.php">← Powrót do list</a>
+        <a href="lists.php?collection=<?php echo urlencode($selectedCollection); ?>">← Powrót do list</a>
         <hr>
     <?php endif; ?>
 
     <table class="lists-table">
-        <thead>
-            <tr>
-                <th>ID</th>
-                <th>Nazwa listy</th>
-                <th>Ilość rekordów</th>
-                <th>Opcje</th>
-            </tr>
-        </thead>
+        <thead><tr><th>ID</th><th>Nazwa listy</th><th>Ilość rekordów</th><th>Opcje</th></tr></thead>
         <tbody>
-            <?php foreach ($lists as $list): 
-                $count = $pdo->query("SELECT COUNT(*) FROM list_items WHERE list_id = " . (int)$list['id'])->fetchColumn();
+            <?php foreach ($lists as $list):
+                $countStmt = $pdo->prepare("SELECT COUNT(*) FROM list_items WHERE list_id = ?");
+                $countStmt->execute([(int)$list['id']]);
+                $count = $countStmt->fetchColumn();
             ?>
             <tr>
                 <td><?php echo $list['id']; ?></td>
                 <td><?php echo htmlspecialchars($list['list_name']); ?></td>
                 <td><?php echo $count; ?></td>
                 <td>
-                    <a href="lists.php?edit=<?php echo $list['id']; ?>" class="edit-btn">Edytuj/Zobacz</a>
+                    <a href="lists.php?collection=<?php echo urlencode($selectedCollection); ?>&edit=<?php echo $list['id']; ?>" class="edit-btn">Edytuj/Zobacz</a>
                     <form method="post" class="form-inline" onsubmit="return confirm('Usunąć tę listę?');">
+                        <input type="hidden" name="collection" value="<?php echo htmlspecialchars($selectedCollection); ?>">
                         <input type="hidden" name="list_id" value="<?php echo $list['id']; ?>">
                         <button type="submit" name="delete_list" class="delete-btn">Usuń</button>
                     </form>

--- a/styles.css
+++ b/styles.css
@@ -57,6 +57,25 @@ h5 {
     margin-bottom: 20px;
 }
 
+.collection-switcher {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    padding: 8px 12px;
+    margin-bottom: 10px;
+    border-radius: 12px;
+    background-color: #bbb;
+}
+
+.collection-switcher #toggleButton {
+    background-color: #000;
+}
+
+.collection-switcher #toggleButton:hover,
+.collection-switcher #toggleButton.active {
+    background-color: #222;
+}
+
 .header-links a {
     margin-left: 15px;
     text-decoration: none;


### PR DESCRIPTION
### Motivation
- Umożliwić wybór kolekcji (Książki Artystyczne, Kolekcja Maszyn, Kolekcja Matryc, Biblioteka) z panelu po lewej stronie i ładowanie/edycję rekordów z odpowiednich zestawów tabel zamiast stałego `karta_ewidencyjna`.
- Przygotować skrypt tworzący nowe tabele kolekcji o tej samej strukturze co istniejące tabele bazowe.

### Description
- Dodano w `index.php` tablicę `$collections`, obsługę parametru `?collection=...` oraz dynamiczne przypisywanie `mainTable` i użycie go w zapytaniach `SHOW COLUMNS` i `SELECT`, a także panel przełącznika kolekcji (szare tło i czarne przyciski) po lewej stronie interfejsu.
- Zaktualizowano front-end: przekazywanie `selectedCollection` do JS i do linku „Karta” (`karta.php?id=...&collection=...`) aby otwierać rekordy właściwej kolekcji.
- Zmieniono `karta.php`, aby używał dynamicznych nazw tabel (`$mainTable`, `$logTable`, `$movesTable`) dla odczytu, zapisu, logowania i przemieszczeń; funkcje `ensureMoveUsernameColumn` i `getNextPrzemieszczenieNumber` zostały zaktualizowane do pracy z przekazanym `movesTable`.
- Dodano `create_collection_tables.sql` tworzący tabele `karta_ewidencyjna_maszyny`, `karta_ewidencyjna_matryce`, `karta_ewidencyjna_bib` oraz odpowiadające im `_log` i `_przemieszczenia` przy użyciu `CREATE TABLE ... LIKE ...` oraz uaktualniono style w `styles.css` dla panelu kolekcji.

### Testing
- Uruchomiono składnię PHP dla zmodyfikowanych plików za pomocą `php -l index.php` i `php -l karta.php`, oba sprawdzenia zakończyły się pomyślnie.
- Uruchomiono lokalny serwer deweloperski `php -S 0.0.0.0:8000` i wykonano automatyczny screenshot interfejsu przy użyciu Playwright, co potwierdziło widoczność nowego panelu kolekcji (screenshot zapisany jako artifact).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6998625266e08320a137368278af2d35)