### PR TITLE
Use local image path when present and fallback to mkalodz bazagfx in karta.php

### DIFF
--- a/karta.php
+++ b/karta.php
@@ -67,21 +67,19 @@ if (!$row) {
 
 // Pobranie ścieżki obrazka
 $image_path = null;
+$image_fallback_path = null;
 if (!empty($row['dokumentacja_wizualna'])) {
     $rawImageValue = trim((string)$row['dokumentacja_wizualna']);
 
-    if (preg_match('#^https?://#i', $rawImageValue) === 1 || str_starts_with($rawImageValue, '/')) {
+    if (preg_match('#^https?://#i', $rawImageValue) === 1) {
         $image_path = $rawImageValue;
     } else {
         $relativeImagePath = ltrim($rawImageValue, '/');
-        $localImagePath = __DIR__ . '/' . $relativeImagePath;
+        $encodedSegments = array_map('rawurlencode', array_filter(explode('/', $relativeImagePath), 'strlen'));
+        $encodedPath = implode('/', $encodedSegments);
 
-        if (is_file($localImagePath)) {
-            $image_path = $relativeImagePath;
-        } else {
-            $encodedSegments = array_map('rawurlencode', array_filter(explode('/', $relativeImagePath), 'strlen'));
-            $image_path = 'https://mkalodz.pl/bazagfx/' . implode('/', $encodedSegments);
-        }
+        $image_path = 'https://baza.mkal.pl/gfx/' . $encodedPath;
+        $image_fallback_path = 'https://mkalodz.pl/bazagfx/' . $encodedPath;
     }
 }
 
@@ -297,7 +295,7 @@ $nextPrzemieszczeniaNumber = getNextPrzemieszczenieNumber($pdo, $movesTable);
         <?php if ($image_path): ?>
             <tr>
                 <td colspan="2">
-                    <img src="<?= $image_path ?>" alt="Obrazek obiektu" width="600">
+                    <img src="<?= htmlspecialchars($image_path) ?>" alt="Obrazek obiektu" width="600"<?php if ($image_fallback_path): ?> onerror='if (this.src !== <?= json_encode($image_fallback_path) ?>) this.src = <?= json_encode($image_fallback_path) ?>;'<?php endif; ?>>
                 </td>
             </tr>
         <?php endif; ?>

--- a/karta.php
+++ b/karta.php
@@ -70,16 +70,19 @@ $image_path = null;
 $image_fallback_path = null;
 if (!empty($row['dokumentacja_wizualna'])) {
     $rawImageValue = trim((string)$row['dokumentacja_wizualna']);
+    $normalizedImageValue = trim($rawImageValue, " '\"");
 
-    if (preg_match('#^https?://#i', $rawImageValue) === 1) {
-        $image_path = $rawImageValue;
-    } else {
-        $relativeImagePath = ltrim($rawImageValue, '/');
-        $encodedSegments = array_map('rawurlencode', array_filter(explode('/', $relativeImagePath), 'strlen'));
-        $encodedPath = implode('/', $encodedSegments);
+    if ($normalizedImageValue !== '') {
+        if (preg_match('#^https?://#i', $normalizedImageValue) === 1) {
+            $image_path = $normalizedImageValue;
+        } else {
+            $relativeImagePath = ltrim($normalizedImageValue, '/');
+            $encodedSegments = array_map('rawurlencode', array_filter(explode('/', $relativeImagePath), 'strlen'));
+            $encodedPath = implode('/', $encodedSegments);
 
-        $image_path = 'https://baza.mkal.pl/gfx/' . $encodedPath;
-        $image_fallback_path = 'https://mkalodz.pl/bazagfx/' . $encodedPath;
+            $image_path = 'https://baza.mkal.pl/gfx/' . $encodedPath;
+            $image_fallback_path = 'https://mkalodz.pl/bazagfx/' . $encodedPath;
+        }
     }
 }
 

--- a/karta.php
+++ b/karta.php
@@ -73,8 +73,15 @@ if (!empty($row['dokumentacja_wizualna'])) {
     if (preg_match('#^https?://#i', $rawImageValue) === 1 || str_starts_with($rawImageValue, '/')) {
         $image_path = $rawImageValue;
     } else {
-        $safeImageName = basename($rawImageValue);
-        $image_path = '/gfx/' . rawurlencode($safeImageName);
+        $relativeImagePath = ltrim($rawImageValue, '/');
+        $localImagePath = __DIR__ . '/' . $relativeImagePath;
+
+        if (is_file($localImagePath)) {
+            $image_path = $relativeImagePath;
+        } else {
+            $encodedSegments = array_map('rawurlencode', array_filter(explode('/', $relativeImagePath), 'strlen'));
+            $image_path = 'https://mkalodz.pl/bazagfx/' . implode('/', $encodedSegments);
+        }
     }
 }
 


### PR DESCRIPTION
### Motivation
- Zapewnienie, że w widoku karty używana będzie podana (bieżąca) ścieżka do pliku obrazka gdy plik istnieje lokalnie, a gdy go brak — zastosowanie bezpiecznego fallbacku do `https://mkalodz.pl/bazagfx/`.

### Description
- Zastąpiono wcześniejsze wymuszenie `/gfx/<basename>` logiką która najpierw sprawdza lokalny plik (`is_file` na ścieżce względem `__DIR__`) i zwraca oryginalną względną ścieżkę gdy plik istnieje, w przeciwnym wypadku buduje fallback URL do `https://mkalodz.pl/bazagfx/` z zakodowanymi segmentami ścieżki, przy jednoczesnym utrzymaniu obsługi pełnych URL-i (`http/https`) i ścieżek zaczynających się od `/`.

### Testing
- Uruchomiono `php -l /workspace/baza/karta.php` i plik przeszedł walidację bez błędów składniowych.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69987f9f81788320ac48ae1010441ca7)