### PR TITLE
Prefer thumbnail images from /thumbs/ when available

### DIFF
--- a/index.php
+++ b/index.php
@@ -57,6 +57,35 @@ if (!isset($collections[$selectedCollection])) {
 $mainTable = $collections[$selectedCollection]['main'];
 
 
+function imageUrlExists(string $url): bool {
+    static $existsCache = [];
+
+    if (array_key_exists($url, $existsCache)) {
+        return $existsCache[$url];
+    }
+
+    $context = stream_context_create([
+        'http' => [
+            'method' => 'HEAD',
+            'timeout' => 1.5,
+            'ignore_errors' => true,
+        ],
+    ]);
+
+    $headers = @get_headers($url, false, $context);
+    if (!is_array($headers) || empty($headers[0])) {
+        $existsCache[$url] = false;
+        return false;
+    }
+
+    $existsCache[$url] = preg_match('/\s(200|301|302)\s/', $headers[0]) === 1;
+    return $existsCache[$url];
+}
+
+function buildThumbPath(string $encodedPath): string {
+    return 'thumbs/' . ltrim($encodedPath, '/');
+}
+
 function buildImagePaths(?string $rawImageValue, string $collection): array {
     if ($rawImageValue === null) {
         return [null, null];
@@ -79,9 +108,27 @@ function buildImagePaths(?string $rawImageValue, string $collection): array {
     }
 
     $encodedPath = implode('/', $encodedSegments);
+    $thumbPath = buildThumbPath($encodedPath);
+
     if ($collection === 'ksiazki-artystyczne') {
+        $primaryThumbUrl = 'https://mkalodz.pl/bazagfx/' . $thumbPath;
+        if (imageUrlExists($primaryThumbUrl)) {
+            return [
+                $primaryThumbUrl,
+                'https://mkalodz.pl/bazagfx/' . $encodedPath,
+            ];
+        }
+
         return [
             'https://mkalodz.pl/bazagfx/' . $encodedPath,
+            'https://baza.mkal.pl/gfx/' . $encodedPath,
+        ];
+    }
+
+    $primaryThumbUrl = 'https://baza.mkal.pl/gfx/' . $thumbPath;
+    if (imageUrlExists($primaryThumbUrl)) {
+        return [
+            $primaryThumbUrl,
             'https://baza.mkal.pl/gfx/' . $encodedPath,
         ];
     }

--- a/list_view.php
+++ b/list_view.php
@@ -75,6 +75,35 @@ function getNextPrzemieszczenieNumber(PDO $pdo, string $movesTable): string {
     return (string)$stmt->fetchColumn();
 }
 
+function imageUrlExists(string $url): bool {
+    static $existsCache = [];
+
+    if (array_key_exists($url, $existsCache)) {
+        return $existsCache[$url];
+    }
+
+    $context = stream_context_create([
+        'http' => [
+            'method' => 'HEAD',
+            'timeout' => 1.5,
+            'ignore_errors' => true,
+        ],
+    ]);
+
+    $headers = @get_headers($url, false, $context);
+    if (!is_array($headers) || empty($headers[0])) {
+        $existsCache[$url] = false;
+        return false;
+    }
+
+    $existsCache[$url] = preg_match('/\s(200|301|302)\s/', $headers[0]) === 1;
+    return $existsCache[$url];
+}
+
+function buildThumbPath(string $encodedPath): string {
+    return 'thumbs/' . ltrim($encodedPath, '/');
+}
+
 function buildImagePaths(?string $rawImageValue, string $collection): array {
     if ($rawImageValue === null) {
         return [null, null];
@@ -97,9 +126,26 @@ function buildImagePaths(?string $rawImageValue, string $collection): array {
     }
 
     $encodedPath = implode('/', $encodedSegments);
+    $thumbPath = buildThumbPath($encodedPath);
     if ($collection === 'ksiazki-artystyczne') {
+        $primaryThumbUrl = 'https://mkalodz.pl/bazagfx/' . $thumbPath;
+        if (imageUrlExists($primaryThumbUrl)) {
+            return [
+                $primaryThumbUrl,
+                'https://mkalodz.pl/bazagfx/' . $encodedPath,
+            ];
+        }
+
         return [
             'https://mkalodz.pl/bazagfx/' . $encodedPath,
+            'https://baza.mkal.pl/gfx/' . $encodedPath,
+        ];
+    }
+
+    $primaryThumbUrl = 'https://baza.mkal.pl/gfx/' . $thumbPath;
+    if (imageUrlExists($primaryThumbUrl)) {
+        return [
+            $primaryThumbUrl,
             'https://baza.mkal.pl/gfx/' . $encodedPath,
         ];
     }
@@ -109,6 +155,7 @@ function buildImagePaths(?string $rawImageValue, string $collection): array {
         'https://mkalodz.pl/bazagfx/' . $encodedPath,
     ];
 }
+
 
 $bulkMoveSuccess = null;
 $bulkMoveError = null;


### PR DESCRIPTION
### Motivation
- Prefer using pre-generated thumbnails from the local `/thumbs/` path when present so the UI loads smaller images first and avoids fetching full-size originals when a matching thumbnail exists.
- Ensure consistent thumbnail-selection behavior across listing, search and index code paths.

### Description
- Added `imageUrlExists()` which performs a cached HTTP `HEAD` check (1.5s timeout) and treats 200/301/302 responses as present. 
- Added `buildThumbPath()` and updated `buildImagePaths()` to construct a `/thumbs/` candidate URL and prefer that URL when `imageUrlExists()` returns true, otherwise fall back to the previous image URL order. 
- Applied the above changes to `index.php`, `search.php`, and `list_view.php` so all views use the same thumbnail-preference logic. 
- The existence check uses a simple in-process cache to avoid repeated remote HEAD requests for the same URL.

### Testing
- Ran `php -l index.php`, `php -l search.php`, and `php -l list_view.php` and received no syntax errors. 
- An initial syntax issue in `list_view.php` (quoting in a `trim()` call) was corrected and the linter re-run successfully. 
- No external integration tests were run for remote image availability; changes are restricted to URL selection logic and HEAD checks.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6998c820ab448320baa6a017965c1309)