### PR TITLE
Dodaj przycisk 'Dodaj następny' po zapisie z mobile add

### DIFF
--- a/karta.php
+++ b/karta.php
@@ -48,6 +48,7 @@ if (!isset($_GET['id'])) {
 }
 
 $id = intval($_GET['id']);
+$isFirstOpenFromMobileAdd = isset($_GET['from_mobile_add']) && $_GET['from_mobile_add'] === '1';
 $searchReturnUrl = '';
 if (isset($_GET['search_return'])) {
     $candidateReturnUrl = trim((string)$_GET['search_return']);
@@ -276,6 +277,9 @@ $nextPrzemieszczeniaNumber = getNextPrzemieszczenieNumber($pdo, $movesTable);
     <a role="button" id="toggleButton" href="index.php?collection=<?php echo urlencode($selectedCollection); ?>">Powrót do listy</a>
     <?php if ($searchReturnUrl !== ''): ?>
         <a role="button" id="toggleButton" href="<?php echo htmlspecialchars($searchReturnUrl); ?>">Powrót do wyszukiwania</a>
+    <?php endif; ?>
+    <?php if ($isFirstOpenFromMobileAdd): ?>
+        <a role="button" class="mobile-next-button" href="mobile_add.php?collection=<?php echo urlencode($selectedCollection); ?>&mobile=1">Dodaj następny</a>
     <?php endif; ?>
 </div>
     

--- a/mobile_add.php
+++ b/mobile_add.php
@@ -257,7 +257,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             ? (int)$new_data[$primaryKeyColumn]
             : (int)$pdo->lastInsertId();
 
-        header('Location: karta.php?id=' . $newId . '&collection=' . urlencode($selectedCollection));
+        header('Location: karta.php?id=' . $newId . '&collection=' . urlencode($selectedCollection) . '&from_mobile_add=1');
         exit;
     } catch (PDOException $e) {
         $formError = 'Błąd dodawania: ' . $e->getMessage();

--- a/styles.css
+++ b/styles.css
@@ -156,6 +156,24 @@ button,
     font-size: 12px;
 }
 
+
+.mobile-next-button {
+    display: inline-block;
+    margin-left: 10px;
+    padding: 16px 26px;
+    font-size: 28px;
+    font-weight: bold;
+    text-transform: uppercase;
+    text-decoration: none;
+    background-color: #0a9b32;
+    color: #fff;
+    border-radius: 12px;
+}
+
+.mobile-next-button:hover {
+    background-color: #067324;
+}
+
 button:hover,
 #toggleButton:hover,
 #toggleColumndButton:hover,


### PR DESCRIPTION
### Motivation
- Gdy `karta.php` otwiera się bezpośrednio po dodaniu nowego rekordu przez `mobile_add.php`, potrzeba szybkiego, wyraźnego przycisku mobilnego „Dodaj następny”, który otworzy formularz `mobile_add` gotowy do dodania kolejnego wpisu. 

### Description
- Zmodyfikowano `mobile_add.php`, aby przekazywał flagę `from_mobile_add=1` przy przekierowaniu na `karta.php`, w `karta.php` dodano odczyt tej flagi i warunkowe wyświetlenie dużego przycisku kierującego do `mobile_add.php?collection=...&mobile=1`, oraz dodano styl `.mobile-next-button` do `styles.css` dla mobilnego wyglądu przycisku. 

### Testing
- Uruchomiono lint PHP z `php -l karta.php` i `php -l mobile_add.php` (oba zakończone sukcesem) oraz wystartowano lokalny serwer deweloperski `php -S` i uruchomiono zautomatyzowany skrypt Playwright, który wygenerował zrzuty ekranu potwierdzające przebieg przekierowania i widoczność elementu (artefakty wygenerowane).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6998ce0a5ed48320b77d704b831d35dd)