### PR TITLE
Ustaw footer na pełną szerokość strony

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -418,12 +418,16 @@ th,
 
 .footer-right {
     position: fixed;
-    right: 5%;
+    left: 0;
+    right: 0;
     bottom: 10px;
+    width: 100%;
+    box-sizing: border-box;
     font-family: var(--font-base);
     font-size: 10px;
     padding: 15px;
     background-color: #fff;
+    text-align: right;
 }
 
 .footer-right a {


### PR DESCRIPTION
### Motivation
- Naprawić szerokość stopki, aby element `.footer-right` zajmował całą szerokość strony zamiast być odsunięty od prawej krawędzi.
- Zachować wizualne wyrównanie zawartości stopki do prawej oraz uwzględnić padding w obliczeniach szerokości.

### Description
- Zmieniono reguły `.footer-right` w `styles.css`, dodając `left: 0`, `right: 0` oraz `width: 100%`.
- Dodano `box-sizing: border-box`, aby padding był liczony wewnątrz szerokości elementu.
- Dodano `text-align: right` aby zachować dotychczasowe wyrównanie treści stopki.

### Testing
- Uruchomiono `php -l index.php` i sprawdzenie zwróciło brak błędów składniowych.
- Uruchomiono `php -l search.php` i sprawdzenie zwróciło brak błędów składniowych.
- Wykonano automatyczny screenshot przez Playwright dla `http://127.0.0.1:8000/index.php`, zapisano artefakt `artifacts/footer-full-width.png`, skrypt zakończył się pomyślnie.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6998e9cac960832081bfbc1e034d4b6c)